### PR TITLE
prevent warning due to empty DLAA log

### DIFF
--- a/deadlink.php
+++ b/deadlink.php
@@ -734,7 +734,7 @@ function isArchived( $urls, $alreadyArchived ) {
     $getURLs = array();
     $returnArray = array( 'result'=>array(), 'errors'=>array() );
     foreach( $urls as $id=>$url ) {
-        if( in_array( $url, $alreadyArchived ) ) {
+        if( is_array( $alreadyArchived ) && in_array( $url, $alreadyArchived ) ) {
             $returnArray['result'][$id] = true;
             continue;
         }

--- a/deadlink.php
+++ b/deadlink.php
@@ -712,7 +712,7 @@ function requestArchive( $urls, $alreadyArchived ) {
     $getURLs = array();
     $returnArray = array( 'result'=>array(), 'errors'=>array(), 'newlyArchived'=>array() );
     foreach( $urls as $id=>$url ) {
-        if( in_array( $url, $alreadyArchived ) ) {
+        if( is_array( $alreadyArchived ) && in_array( $url, $alreadyArchived ) ) {
             $returnArray['result'][$id] = null;
             continue;
         }


### PR DESCRIPTION
If DLAA log is empty, $alreadyArchived will not be an array