### PR TITLE
Fix up deadlink detection code

### DIFF
--- a/IABot/checkIfDead.php
+++ b/IABot/checkIfDead.php
@@ -150,7 +150,7 @@ class checkIfDead {
 		$response = curl_exec( $ch );
 		/* Check for 404 (file not found). */
 		$httpCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-		if( $httpCode == 200 ) {
+		if ( $httpCode == 401 || $httpCode == 503 || $httpCode == 507 ) {
 			return false;
 		} else {
 			return true;

--- a/IABot/checkIfDead.php
+++ b/IABot/checkIfDead.php
@@ -110,6 +110,7 @@ class checkIfDead {
 			if ( $httpCode == 401 || $httpCode == 503 || $httpCode == 507 ) {
 				return false;
 			} else {
+				// Perform a GET request because some servers don't support HEAD requests
 				return $this->checkWithoutHeadRequest( $url );
 			}
 			// Check for error messages in redirected URL string

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -4,42 +4,30 @@ require_once dirname(__FILE__) . '/../IABot/checkIfDead.php';
 
 class checkIfDeadTest extends PHPUnit_Framework_TestCase {
 
-	public function testDeadLinkFalse() {
+	public function testDeadlinksTrue() {
 		$obj = new checkIfDead();
-		$res = $obj->checkDeadlink( 'https://en.wikipedia.org/wiki/Main_Page' );
-		$this->assertFalse( $res );
+		$urls = array(
+					'https://en.wikipedia.org/nothing',
+					'http://www.copart.co.uk/c2/specialSearch.html?_eventId=getLot&execution=e1s2&lotId=10543580',
+					'http://forums.lavag.org/Industrial-EtherNet-EtherNet-IP-t9041.html'
+				);
+		$result = $obj->checkDeadlinks( $urls );
+		$expected = array( true, true, true );
+		$this->assertEquals( $result['results'], $expected );
 	}
 
 
-	public function testDeadLinkTrue() {
+	public function testDeadlinksFalse() {
 		$obj = new checkIfDead();
-		$res = $obj->checkDeadlink( 'https://en.wikipedia.org/nothing' );
-		$this->assertTrue( $res );
-	}
-
-
-	public function testDeadLinkRedirect() {
-		$obj = new checkIfDead();
-		$res = $obj->checkDeadlink( 'https://en.wikipedia.org/w/index.php?title=Republic_of_India' );
-		$this->assertFalse( $res );
-	}
-
-	public function testRedirectToRoot() {
-		$obj = new checkIfDead();
-		$res = $obj->checkDeadlink( 'http://www.copart.co.uk/c2/specialSearch.html?_eventId=getLot&execution=e1s2&lotId=10543580' );
-		$this->assertTrue( $res );
-	}
-
-	public function testRedirectToRootWithSubdomain() {
-		$obj = new checkIfDead();
-		$res = $obj->checkDeadlink( 'http://forums.lavag.org/Industrial-EtherNet-EtherNet-IP-t9041.html' );
-		$this->assertTrue( $res );
-	}
-
-	public function testRedirectToRootWithoutWWW() {
-		$obj = new checkIfDead();
-		$res = $obj->checkDeadlink( 'https://astraldynamics.com' );
-		$this->assertFalse( $res );
+		$urls = array(
+					'https://en.wikipedia.org/wiki/Main_Page',
+					'https://en.wikipedia.org/w/index.php?title=Republic_of_India',
+					'https://astraldynamics.com',
+					'http://www.eonline.com/au/news/386489/2013-grammy-awards-winners-the-complete-list'
+				);
+		$result = $obj->checkDeadlinks( $urls );
+		$expected = array( false, false, false, false );
+		$this->assertEquals( $result['results'], $expected );
 	}
 
 }


### PR DESCRIPTION
I went ahead and cleaned up the code. Changes include:
* Use a better user-agent
* Increase timeout
* Do a GET request when HEAD request fails
* Properly format code
* Include PHPDoc wherever missing
* Fix tests and add new test for grammy link
* Remove unused checkDeadlink function

Note: The GET request is done without a User-Agent as the presence of a User-Agent gives a 403 in case of the grammy awards link.