### PR TITLE
removing CURLOPT_SAFE_UPLOAD setting

### DIFF
--- a/IABot/API.php
+++ b/IABot/API.php
@@ -127,7 +127,6 @@ class API {
 		curl_setopt( self::$globalCurl_handle, CURLOPT_CONNECTTIMEOUT, 10 );
 		curl_setopt( self::$globalCurl_handle, CURLOPT_FOLLOWLOCATION, 0 );
 		curl_setopt( self::$globalCurl_handle, CURLOPT_SSL_VERIFYPEER, false );
-		curl_setopt( self::$globalCurl_handle, CURLOPT_SAFE_UPLOAD, true );
 	}
 
 	/**


### PR DESCRIPTION
Apparently this relatively new curl option is not supported in HipHop
VM 3.6.5, which is what Mediawiki Vagrant runs, so it causes it to
throw a Warning. IABot doesn’t do any file uploading anyway, so it
isn’t needed.