### PR TITLE
Make datetimes can be localized (interface pages)

### DIFF
--- a/IABot/www/Includes/pagefunctions.php
+++ b/IABot/www/Includes/pagefunctions.php
@@ -2,7 +2,7 @@
 
 function getLogText( $logEntry ) {
 	global $userObject, $userCache;
-	$logTemplate = Parser::strftime( '%H:%M, %-e %B %Y', strtotime( $logEntry['log_timestamp'] ) ) . " " .
+	$logTemplate = Parser::strftime( "{{{datetime}}}", strtotime( $logEntry['log_timestamp'] ) ) . " " .
 	               ( !isset( $userCache[$logEntry['log_user']]['user_name'] ) ||
 	                 isset( $userCache[$logEntry['log_user']]['missing_local'] ) ? "" :
 		               "<a href=\"index.php?page=user&id=" . $userCache[$logEntry['log_user']]['user_id'] . "\">" ) .
@@ -118,8 +118,8 @@ function getLogText( $logEntry ) {
 		}
 
 	} elseif( $logEntry['log_action'] == "changeaccess" ) {
-		$logText->assignAfterElement( "logfrom", Parser::strftime( '%H:%M, %-e %B %Y (UTC)', $logEntry['log_from'] ) );
-		$logText->assignAfterElement( "logto", Parser::strftime( '%H:%M, %-e %B %Y (UTC)', $logEntry['log_to'] ) );
+		$logText->assignAfterElement( "logfrom", Parser::strftime( "{{{datetimeutc}}}", $logEntry['log_from'] ) );
+		$logText->assignAfterElement( "logto", Parser::strftime( "{{{datetimeutc}}}", $logEntry['log_to'] ) );
 	} else {
 		$logText->assignAfterElement( "logfrom",
 			( is_null( $logEntry['log_from'] ) ? "{{{none}}}" : $logEntry['log_from'] )
@@ -367,12 +367,12 @@ function loadUserPage( $returnLoader = false ) {
 	$bodyHTML->assignElement( "username", $userObject2->getUsername() );
 	$mainHTML->assignAfterElement( "username", $userObject2->getUsername() );
 	if( $userObject2->getLastAction() > 0 ) $bodyHTML->assignElement( "lastactivitytimestamp",
-	                                                                  Parser::strftime( '%k:%M %-e %B %Y (UTC)',
+	                                                                  Parser::strftime( "{{{datetimeutc}}}",
 	                                                                                    $userObject2->getLastAction()
 	                                                                  )
 	);
 	if( $userObject2->getAuthTimeEpoch() > 0 ) $bodyHTML->assignElement( "lastlogontimestamp",
-	                                                                     Parser::strftime( '%k:%M %-e %B %Y (UTC)',
+	                                                                     Parser::strftime( "{{{datetimeutc}}}",
 	                                                                                       $userObject2->getAuthTimeEpoch(
 	                                                                                       )
 	                                                                     )
@@ -1003,7 +1003,7 @@ function loadInterfaceInfo() {
 		$autoacquireText = "";
 		if( $data['autoacquire']['registered'] != 0 && ( time() - $data['autoacquire']['registered'] ) > 60 ) {
 			$autoacquireText .= "<b>{{{registeredlatest}}}:</b>&nbsp;" .
-			                    Parser::strftime( '%k:%M&nbsp;%-e&nbsp;%B&nbsp;%Y&nbsp;(UTC)',
+			                    Parser::strftime( str_replace(" ","&nbsp;","{{{datetimeutc}}}"),
 			                                      $data['autoacquire']['registered']
 			                    ) . "<br>\n";
 		}
@@ -1806,14 +1806,14 @@ function loadURLInterface() {
 			$bodyHTML->assignElement( "urlformdisplaycontrol", "block" );
 			$bodyHTML->assignAfterElement( "accesstime",
 				( strtotime( $result['access_time'] ) > 0 ?
-					Parser::strftime( '%H:%M %-e %B %Y', strtotime( $result['access_time'] ) ) :
+					Parser::strftime( "{{{datetime}}}", strtotime( $result['access_time'] ) ) :
 					"" )
 			);
 			if( !validatePermission( "alteraccesstime", false ) ) {
 				$bodyHTML->assignElement( "accesstimedisabled", " disabled=\"disabled\"" );
 			}
 			$bodyHTML->assignElement( "deadchecktime", ( strtotime( $result['last_deadCheck'] ) > 0 ?
-				Parser::strftime( '%H:%M %-e %B %Y', strtotime( $result['last_deadCheck'] ) ) : "{{{none}}}" )
+				Parser::strftime( "{{{datetime}}}", strtotime( $result['last_deadCheck'] ) ) : "{{{none}}}" )
 			);
 			if( $result['archived'] == 2 ) {
 				$bodyHTML->assignElement( "archived", "{{{unknown}}}" );
@@ -1946,7 +1946,7 @@ function loadURLInterface() {
 			if( !is_null( $result['archive_url'] ) ) {
 				$bodyHTML->assignElement( "archiveurlvalue", " value=\"{$result['archive_url']}\"" );
 				$bodyHTML->assignElement( "snapshottime",
-				                          Parser::strftime( '%H:%M %-e %B %Y', strtotime( $result['archive_time'] ) )
+				                          Parser::strftime( "{{{datetime}}}", strtotime( $result['archive_time'] ) )
 				);
 			} else {
 				$bodyHTML->assignElement( "snapshottime", "&mdash;" );

--- a/IABot/www/i18n/en.json
+++ b/IABot/www/i18n/en.json
@@ -545,5 +545,7 @@
   "botsubmitdisabledmessage": "Sorry but access to the bot queue for this wiki is disabled.  It may be because the bot isn't approved for use on this wiki.  Please use the <a href=\"index.php?page=runbotsingle\">Single Page Analysis</a> tool instead.",
   "optional": "Optional",
   "accessoverride": "Bypass interface lockout",
-  "unknownuser": "Anonymous/unknown user"
+  "unknownuser": "Anonymous/unknown user",
+  "datetime": "%H:%M, %-e %B %Y",
+  "datetimeutc": "%H:%M, %-e %B %Y (UTC)"
 }


### PR DESCRIPTION
This allows translators to correct illegal datetime formats, for example: https://github.com/cyberpower678/Cyberbot_II/pull/47#discussion_r150055078.

1. This changes is not tested, I don't have a PHP runtime.
2. `%k:%M` looks like an unnecessary difference, I unify it.
3. ` (UTC)`  can also be added internally, but this prevents more flexible internationalization. I'm not sure why there is this difference.
4. This program does not appear to have HTML Safety ([like this](https://github.com/download/i18nline#html-safety)), which may be an issue for preventing malicious translation attacks.