### PR TITLE
Make Cyberpower678 a subscriber, not assignee, for tasks

### DIFF
--- a/IABot/www/Templates/bugreport.html
+++ b/IABot/www/Templates/bugreport.html
@@ -24,5 +24,5 @@
 	</span>-->
 	<input type="submit" value="{{{submit}}}" class="btn btn-primary"/>
 	<input type="hidden" name="projects" value="InternetArchiveBot">
-	<input type="hidden" name="assign" value="Cyberpower678">
+	<input type="hidden" name="subscribers" value="Cyberpower678">
 </form>


### PR DESCRIPTION
We are being gently encouraged to not auto-assign tasks. Now that we have multiple people working on the code, that makes sense. This change makes Cyberpower678 an automatic subscriber to the task but not automatically assigned.