### PR TITLE
Make Cyberpower678 a subscriber, not assignee, for bug reports

### DIFF
--- a/IABot/www/Templates/bugreport.html
+++ b/IABot/www/Templates/bugreport.html
@@ -24,5 +24,5 @@
 	</span>-->
 	<input type="submit" value="{{{submit}}}" class="btn btn-primary"/>
 	<input type="hidden" name="projects" value="InternetArchiveBot">
-	<input type="hidden" name="assign" value="Cyberpower678">
+	<input type="hidden" name="subscribers" value="Cyberpower678">
 </form>


### PR DESCRIPTION
We are being gently encouraged to not auto-assign tasks. https://phabricator.wikimedia.org/T241152

This patch makes Cyberpower678 a default subscriber to newly created tasks, but not the assignee. This makes the most sense seeing as multiple people work on this project now.